### PR TITLE
refactor!: move to tailwind api utils, tailwind v4 support

### DIFF
--- a/lib/config/rules.js
+++ b/lib/config/rules.js
@@ -7,9 +7,9 @@ module.exports = {
   'tailwindcss/classnames-order': 'warn',
   'tailwindcss/enforces-negative-arbitrary-values': 'warn',
   'tailwindcss/enforces-shorthand': 'warn',
-  'tailwindcss/migration-from-tailwind-2': 'warn',
+  'tailwindcss/migration-from-tailwind-2': 'off',
   'tailwindcss/no-arbitrary-value': 'off',
   'tailwindcss/no-custom-classname': 'warn',
-  'tailwindcss/no-contradicting-classname': 'error',
+  'tailwindcss/no-contradicting-classname': 'off',
   'tailwindcss/no-unnecessary-arbitrary-value': 'warn',
 };

--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -10,8 +10,6 @@ const astUtil = require('../util/ast');
 const removeDuplicatesFromClassnamesAndWhitespaces = require('../util/removeDuplicatesFromClassnamesAndWhitespaces');
 const getOption = require('../util/settings');
 const parserUtil = require('../util/parser');
-const order = require('../util/prettier/order');
-const createContextFallback = require('tailwindcss/lib/lib/setupContextUtils').createContext;
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -20,8 +18,6 @@ const createContextFallback = require('tailwindcss/lib/lib/setupContextUtils').c
 // Predefine message for use in context.report conditional.
 // messageId will still be usable in tests.
 const INVALID_CLASSNAMES_ORDER_MSG = 'Invalid Tailwind CSS classnames order';
-
-const contextFallbackCache = new WeakMap();
 
 module.exports = {
   meta: {
@@ -75,13 +71,7 @@ module.exports = {
     const classRegex = getOption(context, 'classRegex');
     const removeDuplicates = getOption(context, 'removeDuplicates');
 
-    const mergedConfig = customConfig.resolve(twConfig);
-    const contextFallback = // Set the created contextFallback in the cache if it does not exist yet.
-      (
-        contextFallbackCache.has(mergedConfig)
-          ? contextFallbackCache
-          : contextFallbackCache.set(mergedConfig, createContextFallback(mergedConfig))
-      ).get(mergedConfig);
+    const utils = customConfig.resolve(twConfig);
 
     //----------------------------------------------------------------------
     // Helpers
@@ -175,7 +165,7 @@ module.exports = {
         return;
       }
 
-      let orderedClassNames = order(classNames, contextFallback).split(' ');
+      let orderedClassNames = utils.getSortedClassNames(classNames);
 
       if (removeDuplicates) {
         removeDuplicatesFromClassnamesAndWhitespaces(orderedClassNames, whitespaces, headSpace, tailSpace);

--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
-const customConfig = require('../util/customConfig');
+const { getSortedClassNames } = require('../util/tailwindAPI');
 const astUtil = require('../util/ast');
 const removeDuplicatesFromClassnamesAndWhitespaces = require('../util/removeDuplicatesFromClassnamesAndWhitespaces');
 const getOption = require('../util/settings');
@@ -70,8 +70,6 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
     const removeDuplicates = getOption(context, 'removeDuplicates');
-
-    const utils = customConfig.resolve(twConfig);
 
     //----------------------------------------------------------------------
     // Helpers
@@ -165,7 +163,7 @@ module.exports = {
         return;
       }
 
-      let orderedClassNames = utils.getSortedClassNames(classNames);
+      let orderedClassNames = getSortedClassNames(twConfig, classNames);
 
       if (removeDuplicates) {
         removeDuplicatesFromClassnamesAndWhitespaces(orderedClassNames, whitespaces, headSpace, tailSpace);

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
-const customConfig = require('../util/customConfig');
+const { getTailwindConfig } = require('../util/tailwindAPI');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
 const getOption = require('../util/settings');
@@ -66,7 +66,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
+    const mergedConfig = getTailwindConfig(twConfig);
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -66,7 +66,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig);
+    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -270,7 +270,15 @@ module.exports = {
             const bodyMatch = inputSet.some(
               (inputClassPattern) => `${mergedConfig.prefix}${inputClassPattern}` === remainingClass.body
             );
-            if ([undefined, null].includes(mergedConfig.theme.size)) {
+            if (
+              !mergedConfig.theme ||
+              !mergedConfig.theme.size ||
+              !mergedConfig.theme.size[remainingClass.value] ||
+              !mergedConfig.theme.width ||
+              !mergedConfig.theme.width[remainingClass.value] ||
+              !mergedConfig.theme.height ||
+              !mergedConfig.theme.height[remainingClass.value]
+            ) {
               return false;
             }
             // w-screen + h-screen ≠ size-screen (Issue #307)

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -6,7 +6,7 @@
 
 const docsUrl = require('../util/docsUrl');
 const defaultGroups = require('../config/groups').groups;
-const customConfig = require('../util/customConfig');
+const { getTailwindConfig } = require('../util/tailwindAPI');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
 const getOption = require('../util/settings');
@@ -67,7 +67,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
+    const mergedConfig = getTailwindConfig(twConfig);
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -67,7 +67,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig);
+    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -72,7 +72,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig);
+    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
-const customConfig = require('../util/customConfig');
+const { getTailwindConfig } = require('../util/tailwindAPI');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
 const getOption = require('../util/settings');
@@ -72,7 +72,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
+    const mergedConfig = getTailwindConfig(twConfig);
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
-const customConfig = require('../util/customConfig');
+const { getTailwindConfig } = require('../util/tailwindAPI');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
 const getOption = require('../util/settings');
@@ -66,7 +66,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
+    const mergedConfig = getTailwindConfig(twConfig);
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -66,7 +66,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig);
+    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -6,7 +6,7 @@
 
 const docsUrl = require('../util/docsUrl');
 const defaultGroups = require('../config/groups').groups;
-const customConfig = require('../util/customConfig');
+const { getTailwindConfig } = require('../util/tailwindAPI');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
 const getOption = require('../util/settings');
@@ -68,7 +68,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
+    const mergedConfig = getTailwindConfig(twConfig);
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -68,7 +68,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig);
+    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -6,7 +6,7 @@
 
 const docsUrl = require('../util/docsUrl');
 const defaultGroups = require('../config/groups').groups;
-const customConfig = require('../util/customConfig');
+const { getTailwindConfig, isValidClassName } = require('../util/tailwindAPI');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
 const getOption = require('../util/settings');
@@ -95,8 +95,7 @@ module.exports = {
     const whitelist = getOption(context, 'whitelist');
     const classRegex = getOption(context, 'classRegex');
 
-    const utils = customConfig.resolve(twConfig);
-    const mergedConfig = utils.context.tailwindConfig;
+    const mergedConfig = getTailwindConfig(twConfig);
 
     //----------------------------------------------------------------------
     // Helpers
@@ -114,7 +113,7 @@ module.exports = {
      */
     const parseForCustomClassNames = (classNames, node) => {
       classNames.forEach((className) => {
-        if (utils.isValidClassName(className)) {
+        if (isValidClassName(twConfig, className)) {
           return; // Lazier is faster... processing next className!
         }
         const idx = groupUtil.getGroupIndex(className, groups, mergedConfig.separator);

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -12,8 +12,6 @@ const groupUtil = require('../util/groupMethods');
 const getOption = require('../util/settings');
 const parserUtil = require('../util/parser');
 const getClassnamesFromCSS = require('../util/cssFiles');
-const createContextFallback = require('tailwindcss/lib/lib/setupContextUtils').createContext;
-const generated = require('../util/generated');
 const escapeRegex = require('../util/regex').escapeRegex;
 
 //------------------------------------------------------------------------------
@@ -97,13 +95,8 @@ module.exports = {
     const whitelist = getOption(context, 'whitelist');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig);
-    const contextFallback = // Set the created contextFallback in the cache if it does not exist yet.
-      (
-        contextFallbackCache.has(mergedConfig)
-          ? contextFallbackCache
-          : contextFallbackCache.set(mergedConfig, createContextFallback(mergedConfig))
-      ).get(mergedConfig);
+    const utils = customConfig.resolve(twConfig);
+    const mergedConfig = utils.context.tailwindConfig;
 
     //----------------------------------------------------------------------
     // Helpers
@@ -121,8 +114,7 @@ module.exports = {
      */
     const parseForCustomClassNames = (classNames, node) => {
       classNames.forEach((className) => {
-        const gen = generated(className, contextFallback);
-        if (gen.length) {
+        if (utils.isValidClassName(className)) {
           return; // Lazier is faster... processing next className!
         }
         const idx = groupUtil.getGroupIndex(className, groups, mergedConfig.separator);

--- a/lib/rules/no-unnecessary-arbitrary-value.js
+++ b/lib/rules/no-unnecessary-arbitrary-value.js
@@ -72,7 +72,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig);
+    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
     const groups = groupUtil.getGroups(defaultGroups, mergedConfig);
     const configKeys = groupUtil.getGroupConfigKeys(defaultGroups);
     let parentTemplateLiteral = null;

--- a/lib/rules/no-unnecessary-arbitrary-value.js
+++ b/lib/rules/no-unnecessary-arbitrary-value.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
-const customConfig = require('../util/customConfig');
+const { getTailwindConfig } = require('../util/tailwindAPI');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
 const getOption = require('../util/settings');
@@ -72,7 +72,7 @@ module.exports = {
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
 
-    const mergedConfig = customConfig.resolve(twConfig).context.tailwindConfig;
+    const mergedConfig = getTailwindConfig(twConfig);
     const groups = groupUtil.getGroups(defaultGroups, mergedConfig);
     const configKeys = groupUtil.getGroupConfigKeys(defaultGroups);
     let parentTemplateLiteral = null;

--- a/lib/rules/no-unnecessary-arbitrary-value.js
+++ b/lib/rules/no-unnecessary-arbitrary-value.js
@@ -193,7 +193,7 @@ module.exports = {
           const isNegativeClass = parsed.body.indexOf('-') === 0;
           const isNegativeValue = arbitraryValue.indexOf('-') === 0;
           const configurationKey = configKeys[groupIdx];
-          const configuration = mergedConfig.theme[configurationKey];
+          const configuration = mergedConfig.theme?.[configurationKey];
           if ([undefined, null].includes(configuration)) {
             return false;
           }

--- a/lib/util/customConfig.js
+++ b/lib/util/customConfig.js
@@ -1,76 +1,16 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const resolveConfig = require('tailwindcss/resolveConfig');
-let twLoadConfig;
-
-try {
-  twLoadConfig = require('tailwindcss/lib/lib/load-config');
-} catch (err) {
-  twLoadConfig = null;
-}
+const { TailwindUtils } = require('tailwind-api-utils');
 
 // for nativewind preset
 process.env.TAILWIND_MODE = 'build';
 
 const CHECK_REFRESH_RATE = 1_000;
 let lastCheck = null;
+/**
+ * @type {Map<string, TailwindUtils}>}
+ */
 let mergedConfig = new Map();
-let lastModifiedDate = new Map();
-
-/**
- * @see https://stackoverflow.com/questions/9210542/node-js-require-cache-possible-to-invalidate
- * @param {string} module The path to the module
- * @returns the module's export
- */
-function requireUncached(module) {
-  delete require.cache[require.resolve(module)];
-  if (twLoadConfig === null) {
-    // Using native loading
-    return require(module);
-  } else {
-    // Using Tailwind CSS's loadConfig utility
-    return twLoadConfig.loadConfig(module);
-  }
-}
-
-/**
- * Load the config from a path string or parsed from an object
- * @param {string|Object} config
- * @returns `null` when unchanged, `{}` when not found
- */
-function loadConfig(config) {
-  let loadedConfig = null;
-  if (typeof config === 'string') {
-    const resolvedPath = path.isAbsolute(config) ? config : path.join(path.resolve(), config);
-    try {
-      const stats = fs.statSync(resolvedPath);
-      const mtime = `${stats.mtime || ''}`;
-      if (stats === null) {
-        // Default to no config
-        loadedConfig = {};
-      } else if (lastModifiedDate.get(resolvedPath) !== mtime) {
-        // Load the config based on path
-        lastModifiedDate.set(resolvedPath, mtime);
-        loadedConfig = requireUncached(resolvedPath);
-      } else {
-        // Unchanged config
-        loadedConfig = null;
-      }
-    } catch (err) {
-      // Default to no config
-      loadedConfig = {};
-    } finally {
-      return loadedConfig;
-    }
-  } else {
-    if (typeof config === 'object' && config !== null) {
-      return config;
-    }
-    return {};
-  }
-}
 
 function resolve(twConfig) {
   const newConfig = mergedConfig.get(twConfig) === undefined;
@@ -78,11 +18,9 @@ function resolve(twConfig) {
   const expired = now - lastCheck > CHECK_REFRESH_RATE;
   if (newConfig || expired) {
     lastCheck = now;
-    const userConfig = loadConfig(twConfig);
-    // userConfig is null when config file was not modified
-    if (userConfig !== null) {
-      mergedConfig.set(twConfig, resolveConfig(userConfig));
-    }
+    const tailwindUtils = new TailwindUtils();
+    tailwindUtils.loadConfig(twConfig);
+    mergedConfig.set(twConfig, tailwindUtils);
   }
   return mergedConfig.get(twConfig);
 }

--- a/lib/util/customConfig.js
+++ b/lib/util/customConfig.js
@@ -12,14 +12,14 @@ let lastCheck = null;
  */
 let mergedConfig = new Map();
 
-function resolve(twConfig) {
+async function resolve(twConfig) {
   const newConfig = mergedConfig.get(twConfig) === undefined;
   const now = Date.now();
   const expired = now - lastCheck > CHECK_REFRESH_RATE;
   if (newConfig || expired) {
     lastCheck = now;
     const tailwindUtils = new TailwindUtils();
-    tailwindUtils.loadConfig(twConfig);
+    await tailwindUtils.loadConfig(twConfig);
     mergedConfig.set(twConfig, tailwindUtils);
   }
   return mergedConfig.get(twConfig);

--- a/lib/util/customConfig.js
+++ b/lib/util/customConfig.js
@@ -5,21 +5,20 @@ const { TailwindUtils } = require('tailwind-api-utils');
 // for nativewind preset
 process.env.TAILWIND_MODE = 'build';
 
-const CHECK_REFRESH_RATE = 1_000;
-let lastCheck = null;
+const CHECK_REFRESH_RATE = 10_000;
+let lastCheck = new Map();
 /**
  * @type {Map<string, TailwindUtils}>}
  */
 let mergedConfig = new Map();
 
-async function resolve(twConfig) {
+function resolve(twConfig) {
   const newConfig = mergedConfig.get(twConfig) === undefined;
   const now = Date.now();
-  const expired = now - lastCheck > CHECK_REFRESH_RATE;
+  const expired = now - lastCheck.get(twConfig) > CHECK_REFRESH_RATE;
   if (newConfig || expired) {
-    lastCheck = now;
+    lastCheck.set(twConfig, now);
     const tailwindUtils = new TailwindUtils();
-    await tailwindUtils.loadConfig(twConfig);
     mergedConfig.set(twConfig, tailwindUtils);
   }
   return mergedConfig.get(twConfig);

--- a/lib/util/getSortedClassNamesWorker.js
+++ b/lib/util/getSortedClassNamesWorker.js
@@ -2,6 +2,9 @@ const { runAsWorker } = require('synckit');
 const { resolve } = require('./customConfig');
 
 runAsWorker(async (twConfig, classNames) => {
-  const tailwindUtils = await resolve(twConfig);
+  const tailwindUtils = resolve(twConfig);
+  if (!tailwindUtils.context) {
+    await tailwindUtils.loadConfig(twConfig);
+  }
   return tailwindUtils.getSortedClassNames(classNames);
 });

--- a/lib/util/getSortedClassNamesWorker.js
+++ b/lib/util/getSortedClassNamesWorker.js
@@ -1,0 +1,7 @@
+const { runAsWorker } = require('synckit');
+const { resolve } = require('./customConfig');
+
+runAsWorker(async (twConfig, classNames) => {
+  const tailwindUtils = await resolve(twConfig);
+  return tailwindUtils.getSortedClassNames(classNames);
+});

--- a/lib/util/getTailwindConfigWorker.js
+++ b/lib/util/getTailwindConfigWorker.js
@@ -1,0 +1,7 @@
+const { runAsWorker } = require('synckit');
+const { resolve } = require('./customConfig');
+
+runAsWorker(async (twConfig) => {
+  const tailwindUtils = await resolve(twConfig);
+  return tailwindUtils.context.tailwindConfig;
+});

--- a/lib/util/getTailwindConfigWorker.js
+++ b/lib/util/getTailwindConfigWorker.js
@@ -2,6 +2,9 @@ const { runAsWorker } = require('synckit');
 const { resolve } = require('./customConfig');
 
 runAsWorker(async (twConfig) => {
-  const tailwindUtils = await resolve(twConfig);
+  const tailwindUtils = resolve(twConfig);
+  if (!tailwindUtils.context) {
+    await tailwindUtils.loadConfig(twConfig);
+  }
   return tailwindUtils.context.tailwindConfig;
 });

--- a/lib/util/groupMethods.js
+++ b/lib/util/groupMethods.js
@@ -39,7 +39,7 @@ function escapeSpecialChars(str) {
  * @returns {String} The suffix or an empty string
  */
 function generateOptionalOpacitySuffix(config) {
-  const opacityKeys = !config.theme['opacity'] ? [] : Object.keys(config.theme['opacity']);
+  const opacityKeys = !config.theme?.['opacity'] ? [] : Object.keys(config.theme['opacity']);
   opacityKeys.push('\\[(\\d*\\.?\\d*)%?\\]');
   return `(\\/(${opacityKeys.join('|')}))?`;
 }
@@ -97,6 +97,9 @@ function generateOptions(propName, keys, config, isNegative = false) {
       // https://tailwindcss.com/docs/customizing-colors#color-object-syntax
       const options = [];
       keys.forEach((k) => {
+        if (!config.theme?.[propName]?.[k] && !config.theme?.colors?.[k]) {
+          return;
+        }
         const color = config.theme[propName][k] || config.theme.colors[k];
         if (typeof color === 'string') {
           options.push(escapeSpecialChars(k) + opacitySuffixes);

--- a/lib/util/isValidClassNameWorker.js
+++ b/lib/util/isValidClassNameWorker.js
@@ -1,0 +1,7 @@
+const { runAsWorker } = require('synckit');
+const { resolve } = require('./customConfig');
+
+runAsWorker(async (twConfig, className) => {
+  const tailwindUtils = await resolve(twConfig);
+  return tailwindUtils.isValidClassName(className);
+});

--- a/lib/util/isValidClassNameWorker.js
+++ b/lib/util/isValidClassNameWorker.js
@@ -2,6 +2,9 @@ const { runAsWorker } = require('synckit');
 const { resolve } = require('./customConfig');
 
 runAsWorker(async (twConfig, className) => {
-  const tailwindUtils = await resolve(twConfig);
+  const tailwindUtils = resolve(twConfig);
+  if (!tailwindUtils.context) {
+    await tailwindUtils.loadConfig(twConfig);
+  }
   return tailwindUtils.isValidClassName(className);
 });

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -1,12 +1,4 @@
 'use strict';
-let resolveDefaultConfigPathAlias;
-
-try {
-  const { resolveDefaultConfigPath } = require('tailwindcss/lib/util/resolveConfigPath');
-  resolveDefaultConfigPathAlias = resolveDefaultConfigPath;
-} catch (err) {
-  resolveDefaultConfigPathAlias = null;
-}
 
 function getOption(context, name) {
   // Options (defined at rule level)
@@ -27,11 +19,7 @@ function getOption(context, name) {
     case 'classRegex':
       return '^class(Name)?$';
     case 'config':
-      if (resolveDefaultConfigPathAlias === null) {
-        return 'tailwind.config.js';
-      } else {
-        return resolveDefaultConfigPathAlias();
-      }
+      return {};
     case 'cssFiles':
       return ['**/*.css', '!**/node_modules', '!**/.*', '!**/dist', '!**/build'];
     case 'cssFilesRefreshRate':

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -8,6 +8,18 @@ try {
   resolveDefaultConfigPathAlias = null;
 }
 
+const CAN_NOT_RESOLVE_TAILWIND_CONFIG_PATH_ERROR =
+  'Cannot resolve default tailwindcss config path. Please manually set the config option.';
+
+function notice() {
+  if (process.env.NODE_ENV !== 'test') {
+    console.warn(CAN_NOT_RESOLVE_TAILWIND_CONFIG_PATH_ERROR);
+    return {};
+  } else {
+    throw new Error(CAN_NOT_RESOLVE_TAILWIND_CONFIG_PATH_ERROR);
+  }
+}
+
 function getOption(context, name) {
   // Options (defined at rule level)
   const options = context.options[0] || {};
@@ -28,13 +40,11 @@ function getOption(context, name) {
       return '^class(Name)?$';
     case 'config':
       if (resolveDefaultConfigPathAlias === null) {
-        console.warn('Cannot resolve default config path. Please manually set the config option.');
-        return {};
+        return notice();
       } else {
         const path = resolveDefaultConfigPathAlias();
         if (!path) {
-          console.warn('Cannot resolve default config path. Please manually set the config option.');
-          return {};
+          return notice();
         }
         return path;
       }

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -11,14 +11,6 @@ try {
 const CAN_NOT_RESOLVE_TAILWIND_CONFIG_PATH_ERROR =
   'Cannot resolve default tailwindcss config path. Please manually set the config option.';
 
-function notice() {
-  if (process.env.NODE_ENV === 'test') {
-    return {};
-  } else {
-    throw new Error(CAN_NOT_RESOLVE_TAILWIND_CONFIG_PATH_ERROR);
-  }
-}
-
 function getOption(context, name) {
   // Options (defined at rule level)
   const options = context.options[0] || {};
@@ -39,11 +31,13 @@ function getOption(context, name) {
       return '^class(Name)?$';
     case 'config':
       if (resolveDefaultConfigPathAlias === null) {
-        return notice();
+        console.warn(CAN_NOT_RESOLVE_TAILWIND_CONFIG_PATH_ERROR);
+        return {};
       } else {
         const path = resolveDefaultConfigPathAlias();
         if (!path) {
-          return notice();
+          console.warn(CAN_NOT_RESOLVE_TAILWIND_CONFIG_PATH_ERROR);
+          return {};
         }
         return path;
       }

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -1,4 +1,12 @@
 'use strict';
+let resolveDefaultConfigPathAlias;
+
+try {
+  const { resolveDefaultConfigPath } = require('tailwindcss/lib/util/resolveConfigPath');
+  resolveDefaultConfigPathAlias = resolveDefaultConfigPath;
+} catch (err) {
+  resolveDefaultConfigPathAlias = null;
+}
 
 function getOption(context, name) {
   // Options (defined at rule level)
@@ -19,7 +27,17 @@ function getOption(context, name) {
     case 'classRegex':
       return '^class(Name)?$';
     case 'config':
-      return {};
+      if (resolveDefaultConfigPathAlias === null) {
+        console.warn('Cannot resolve default config path. Please manually set the config option.');
+        return {};
+      } else {
+        const path = resolveDefaultConfigPathAlias();
+        if (!path) {
+          console.warn('Cannot resolve default config path. Please manually set the config option.');
+          return {};
+        }
+        return path;
+      }
     case 'cssFiles':
       return ['**/*.css', '!**/node_modules', '!**/.*', '!**/dist', '!**/build'];
     case 'cssFilesRefreshRate':

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -12,8 +12,7 @@ const CAN_NOT_RESOLVE_TAILWIND_CONFIG_PATH_ERROR =
   'Cannot resolve default tailwindcss config path. Please manually set the config option.';
 
 function notice() {
-  if (process.env.NODE_ENV !== 'test') {
-    console.warn(CAN_NOT_RESOLVE_TAILWIND_CONFIG_PATH_ERROR);
+  if (process.env.NODE_ENV === 'test') {
     return {};
   } else {
     throw new Error(CAN_NOT_RESOLVE_TAILWIND_CONFIG_PATH_ERROR);

--- a/lib/util/tailwindAPI.js
+++ b/lib/util/tailwindAPI.js
@@ -1,0 +1,11 @@
+const { createSyncFn } = require('synckit');
+
+const getTailwindConfig = createSyncFn(require.resolve('./getTailwindConfigWorker.js'));
+const getSortedClassNames = createSyncFn(require.resolve('./getSortedClassNamesWorker.js'));
+const isValidClassName = createSyncFn(require.resolve('./isValidClassNameWorker.js'));
+
+module.exports = {
+  getTailwindConfig,
+  getSortedClassNames,
+  isValidClassName,
+};

--- a/lib/util/tailwindAPI.js
+++ b/lib/util/tailwindAPI.js
@@ -1,8 +1,42 @@
 const { createSyncFn } = require('synckit');
 
-const getTailwindConfig = createSyncFn(require.resolve('./getTailwindConfigWorker.js'));
-const getSortedClassNames = createSyncFn(require.resolve('./getSortedClassNamesWorker.js'));
-const isValidClassName = createSyncFn(require.resolve('./isValidClassNameWorker.js'));
+const { resolve } = require('./customConfig');
+const getTailwindConfigWorker = createSyncFn(require.resolve('./getTailwindConfigWorker.js'));
+const getSortedClassNamesWorker = createSyncFn(require.resolve('./getSortedClassNamesWorker.js'));
+const isValidClassNameWorker = createSyncFn(require.resolve('./isValidClassNameWorker.js'));
+
+const getTailwindConfig = (twConfig) => {
+  const utils = resolve(twConfig);
+  if (utils.isV4) {
+    return getTailwindConfigWorker(twConfig);
+  }
+  if (!utils.context) {
+    utils.loadConfigV3(twConfig);
+  }
+  return utils.context.tailwindConfig;
+};
+
+const getSortedClassNames = (twConfig, classNames) => {
+  const utils = resolve(twConfig);
+  if (utils.isV4) {
+    return getSortedClassNamesWorker(twConfig, classNames);
+  }
+  if (!utils.context) {
+    utils.loadConfigV3(twConfig);
+  }
+  return utils.getSortedClassNames(classNames);
+};
+
+const isValidClassName = (twConfig, className) => {
+  const utils = resolve(twConfig);
+  if (utils.isV4) {
+    return isValidClassNameWorker(twConfig, className);
+  }
+  if (!utils.context) {
+    utils.loadConfigV3(twConfig);
+  }
+  return utils.isValidClassName(className);
+};
 
 module.exports = {
   getTailwindConfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyoban/eslint-plugin-tailwindcss",
-      "version": "4.0.0-alpha.3",
+      "version": "4.0.0-alpha.7",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",
         "postcss": "^8.4.4",
         "synckit": "^0.11.4",
-        "tailwind-api-utils": "^1.0.1"
+        "tailwind-api-utils": "^1.0.2"
       },
       "devDependencies": {
         "@angular-eslint/template-parser": "^15.2.0",
@@ -2592,9 +2592,9 @@
       "license": "0BSD"
     },
     "node_modules/tailwind-api-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.1.tgz",
-      "integrity": "sha512-gLaMvYOZi95eMYSzqaEtB0mcQIo+A3NGQIWsodBht2/F0gt421N2sWOz1cHto0r5K14aZSUenzLeS7FVSdTZyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.2.tgz",
+      "integrity": "sha512-MMbPkZj1iSAmpqXEdB4F1dp6n1DZ7cZvw41ymhOu26LTKg0+AQnct1w2P6CnYju384FzrHCMk7lMDQXEaQPa7w==",
       "license": "MIT",
       "dependencies": {
         "enhanced-resolve": "^5.18.1",
@@ -4767,9 +4767,9 @@
       }
     },
     "tailwind-api-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.1.tgz",
-      "integrity": "sha512-gLaMvYOZi95eMYSzqaEtB0mcQIo+A3NGQIWsodBht2/F0gt421N2sWOz1cHto0r5K14aZSUenzLeS7FVSdTZyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.2.tgz",
+      "integrity": "sha512-MMbPkZj1iSAmpqXEdB4F1dp6n1DZ7cZvw41ymhOu26LTKg0+AQnct1w2P6CnYju384FzrHCMk7lMDQXEaQPa7w==",
       "requires": {
         "enhanced-resolve": "^5.18.1",
         "jiti": "^2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.10",
+  "version": "4.0.0-alpha.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyoban/eslint-plugin-tailwindcss",
-      "version": "4.0.0-alpha.10",
+      "version": "4.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",
-        "postcss": "^8.4.4"
+        "postcss": "^8.4.4",
+        "tailwind-api-utils": "^1.0.0"
       },
       "devDependencies": {
         "@angular-eslint/template-parser": "^15.2.0",
@@ -48,7 +49,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -169,7 +169,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -183,7 +182,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -192,7 +190,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -200,14 +197,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.18",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
       "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
@@ -216,8 +211,7 @@
     "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -404,10 +398,10 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -461,14 +455,12 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -480,8 +472,7 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -528,14 +519,12 @@
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -544,7 +533,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -615,7 +603,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -704,7 +691,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -789,7 +775,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -797,8 +782,13 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/confbox": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -828,7 +818,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -890,8 +879,7 @@
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -917,8 +905,7 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -943,6 +930,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -1119,6 +1119,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.5.tgz",
+      "integrity": "sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1249,14 +1255,12 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -1269,8 +1273,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -1347,6 +1350,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -1357,7 +1366,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -1412,7 +1420,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1421,14 +1428,12 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -1440,7 +1445,6 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
       "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
-      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -1524,7 +1528,6 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-      "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -1570,7 +1573,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -1578,8 +1580,24 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/local-pkg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
+      "integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.0.1",
+        "quansync": "^0.2.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -1681,12 +1699,40 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "pathe": "^2.0.1",
+        "pkg-types": "^1.3.0",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/mocha": {
@@ -1802,7 +1848,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -1842,7 +1887,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1860,7 +1904,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1869,7 +1912,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -1878,7 +1920,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -1955,7 +1996,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1972,8 +2012,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -1983,6 +2022,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -2004,7 +2049,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2013,9 +2057,19 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.1.0.tgz",
+      "integrity": "sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.1",
+        "exsolve": "^1.0.1",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/postcss": {
@@ -2049,7 +2103,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -2066,7 +2119,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
@@ -2085,7 +2137,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
       "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
-      "dev": true,
       "dependencies": {
         "lilconfig": "^2.0.5",
         "yaml": "^2.1.1"
@@ -2114,7 +2165,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
       "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
-      "dev": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.11"
       },
@@ -2133,7 +2183,6 @@
       "version": "6.0.12",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz",
       "integrity": "sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==",
-      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2158,8 +2207,7 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -2178,6 +2226,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
+      "integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -2211,7 +2275,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -2220,7 +2283,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -2241,7 +2303,6 @@
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
       "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
@@ -2448,7 +2509,6 @@
       "version": "3.32.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.32.0.tgz",
       "integrity": "sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -2470,7 +2530,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2490,7 +2549,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2498,11 +2556,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-api-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.0.tgz",
+      "integrity": "sha512-VDw13nJWSyMUynMPerDuD/roQLsoc/DaFlKRADYrSpiyn7hBtUHc1F/tu1AhVoKT3wvPzuS3gA3CXm9dGxJm5w==",
+      "license": "MIT",
+      "dependencies": {
+        "enhanced-resolve": "^5.18.1",
+        "jiti": "^2.4.2",
+        "local-pkg": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hyoban"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.3.0 || ^4.0.0 || ^4.0.0-beta"
+      }
+    },
+    "node_modules/tailwind-api-utils/node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.0.tgz",
       "integrity": "sha512-VigzymniH77knD1dryXbyxR+ePHihHociZbXnLZHUyzf2MMs2ZVqlUrZ3FvpXP8pno9JzmILt1sZPD19M3IxtA==",
-      "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -2539,7 +2622,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -2551,13 +2633,21 @@
       "version": "6.0.12",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz",
       "integrity": "sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==",
-      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/text-table": {
@@ -2570,7 +2660,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -2579,7 +2668,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -2601,8 +2689,7 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/tslib": {
       "version": "1.14.1",
@@ -2662,6 +2749,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "license": "MIT"
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2674,8 +2767,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.4.2",
@@ -2775,8 +2867,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -2797,7 +2888,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
       "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
-      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -2867,8 +2957,7 @@
     "@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="
     },
     "@angular-eslint/bundled-angular-compiler": {
       "version": "15.2.0",
@@ -2951,7 +3040,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2961,26 +3049,22 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.18",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
       "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
@@ -2989,8 +3073,7 @@
         "@jridgewell/sourcemap-codec": {
           "version": "1.4.14",
           "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-          "dev": true
+          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         }
       }
     },
@@ -3112,10 +3195,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -3151,14 +3233,12 @@
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -3167,8 +3247,7 @@
     "arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "argparse": {
       "version": "2.0.1",
@@ -3199,20 +3278,17 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3260,8 +3336,7 @@
     "camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
       "version": "1.0.30001286",
@@ -3324,7 +3399,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -3393,14 +3467,17 @@
     "commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "confbox": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -3426,8 +3503,7 @@
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "daisyui": {
       "version": "2.6.4",
@@ -3465,8 +3541,7 @@
     "didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
     "diff": {
       "version": "5.0.0",
@@ -3486,8 +3561,7 @@
     "dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -3509,6 +3583,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "enhanced-resolve": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -3636,6 +3719,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "exsolve": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.5.tgz",
+      "integrity": "sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3738,21 +3826,18 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -3805,6 +3890,11 @@
         "slash": "^3.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
     "graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3815,7 +3905,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3852,7 +3941,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3861,14 +3949,12 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -3877,7 +3963,6 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
       "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -3933,8 +4018,7 @@
     "jiti": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-      "dev": true
+      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -3970,14 +4054,22 @@
     "lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "dev": true
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="
     },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "local-pkg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
+      "integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
+      "requires": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.0.1",
+        "quansync": "^0.2.8"
+      }
     },
     "locate-path": {
       "version": "6.0.0",
@@ -4055,9 +4147,36 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
+      }
+    },
+    "mlly": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "requires": {
+        "acorn": "^8.14.0",
+        "pathe": "^2.0.1",
+        "pkg-types": "^1.3.0",
+        "ufo": "^1.5.4"
+      },
+      "dependencies": {
+        "confbox": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+          "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="
+        },
+        "pkg-types": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+          "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+          "requires": {
+            "confbox": "^0.1.8",
+            "mlly": "^1.7.4",
+            "pathe": "^2.0.1"
+          }
+        }
       }
     },
     "mocha": {
@@ -4146,7 +4265,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "requires": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -4173,8 +4291,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -4185,20 +4302,17 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4253,8 +4367,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -4265,14 +4378,18 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
+    },
+    "pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -4287,14 +4404,22 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
     },
     "pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
-      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
-      "dev": true
+      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ=="
+    },
+    "pkg-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.1.0.tgz",
+      "integrity": "sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==",
+      "requires": {
+        "confbox": "^0.2.1",
+        "exsolve": "^1.0.1",
+        "pathe": "^2.0.3"
+      }
     },
     "postcss": {
       "version": "8.4.38",
@@ -4310,7 +4435,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "requires": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -4321,7 +4445,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "requires": {
         "camelcase-css": "^2.0.1"
       }
@@ -4330,7 +4453,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
       "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
-      "dev": true,
       "requires": {
         "lilconfig": "^2.0.5",
         "yaml": "^2.1.1"
@@ -4340,7 +4462,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
       "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
-      "dev": true,
       "requires": {
         "postcss-selector-parser": "^6.0.11"
       },
@@ -4349,7 +4470,6 @@
           "version": "6.0.12",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz",
           "integrity": "sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==",
-          "dev": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -4370,8 +4490,7 @@
     "postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -4384,6 +4503,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
+    },
+    "quansync": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
+      "integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -4403,7 +4527,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "requires": {
         "pify": "^2.3.0"
       }
@@ -4412,7 +4535,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -4427,7 +4549,6 @@
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
       "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
@@ -4559,7 +4680,6 @@
       "version": "3.32.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.32.0.tgz",
       "integrity": "sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==",
-      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -4574,7 +4694,6 @@
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -4589,14 +4708,29 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "tailwind-api-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.0.tgz",
+      "integrity": "sha512-VDw13nJWSyMUynMPerDuD/roQLsoc/DaFlKRADYrSpiyn7hBtUHc1F/tu1AhVoKT3wvPzuS3gA3CXm9dGxJm5w==",
+      "requires": {
+        "enhanced-resolve": "^5.18.1",
+        "jiti": "^2.4.2",
+        "local-pkg": "^1.1.1"
+      },
+      "dependencies": {
+        "jiti": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+          "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="
+        }
+      }
     },
     "tailwindcss": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.0.tgz",
       "integrity": "sha512-VigzymniH77knD1dryXbyxR+ePHihHociZbXnLZHUyzf2MMs2ZVqlUrZ3FvpXP8pno9JzmILt1sZPD19M3IxtA==",
-      "dev": true,
       "requires": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -4626,7 +4760,6 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-          "dev": true,
           "requires": {
             "is-glob": "^4.0.3"
           }
@@ -4635,13 +4768,17 @@
           "version": "6.0.12",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz",
           "integrity": "sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==",
-          "dev": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
           }
         }
       }
+    },
+    "tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "text-table": {
       "version": "0.2.0",
@@ -4653,7 +4790,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "requires": {
         "any-promise": "^1.0.0"
       }
@@ -4662,7 +4798,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
@@ -4678,8 +4813,7 @@
     "ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "tslib": {
       "version": "1.14.1",
@@ -4717,6 +4851,11 @@
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
+    "ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4729,8 +4868,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "vue-eslint-parser": {
       "version": "9.4.2",
@@ -4802,8 +4940,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "y18n": {
       "version": "5.0.8",
@@ -4820,8 +4957,7 @@
     "yaml": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
-      "dev": true
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.2",
+  "version": "4.0.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyoban/eslint-plugin-tailwindcss",
-      "version": "4.0.0-alpha.2",
+      "version": "4.0.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.11",
+  "version": "4.0.0-alpha.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyoban/eslint-plugin-tailwindcss",
-      "version": "4.0.0-alpha.11",
+      "version": "4.0.0-alpha.12",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.8",
+  "version": "4.0.0-alpha.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyoban/eslint-plugin-tailwindcss",
-      "version": "4.0.0-alpha.8",
+      "version": "4.0.0-alpha.9",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "eslint-plugin-tailwindcss",
-  "version": "3.18.0",
+  "name": "@hyoban/eslint-plugin-tailwindcss",
+  "version": "4.0.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "eslint-plugin-tailwindcss",
-      "version": "3.18.0",
+      "name": "@hyoban/eslint-plugin-tailwindcss",
+      "version": "4.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",
         "postcss": "^8.4.4",
-        "tailwind-api-utils": "^1.0.0"
+        "synckit": "^0.11.4",
+        "tailwind-api-utils": "^1.0.1"
       },
       "devDependencies": {
         "@angular-eslint/template-parser": "^15.2.0",
@@ -243,6 +244,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
+      "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@tailwindcss/aspect-ratio": {
@@ -2556,10 +2569,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.4.tgz",
+      "integrity": "sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/synckit/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tailwind-api-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.0.tgz",
-      "integrity": "sha512-VDw13nJWSyMUynMPerDuD/roQLsoc/DaFlKRADYrSpiyn7hBtUHc1F/tu1AhVoKT3wvPzuS3gA3CXm9dGxJm5w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.1.tgz",
+      "integrity": "sha512-gLaMvYOZi95eMYSzqaEtB0mcQIo+A3NGQIWsodBht2/F0gt421N2sWOz1cHto0r5K14aZSUenzLeS7FVSdTZyw==",
       "license": "MIT",
       "dependencies": {
         "enhanced-resolve": "^5.18.1",
@@ -3099,6 +3134,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@pkgr/core": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
+      "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw=="
     },
     "@tailwindcss/aspect-ratio": {
       "version": "0.4.2",
@@ -4710,10 +4750,26 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "synckit": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.4.tgz",
+      "integrity": "sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ==",
+      "requires": {
+        "@pkgr/core": "^0.2.3",
+        "tslib": "^2.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
     "tailwind-api-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.0.tgz",
-      "integrity": "sha512-VDw13nJWSyMUynMPerDuD/roQLsoc/DaFlKRADYrSpiyn7hBtUHc1F/tu1AhVoKT3wvPzuS3gA3CXm9dGxJm5w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.1.tgz",
+      "integrity": "sha512-gLaMvYOZi95eMYSzqaEtB0mcQIo+A3NGQIWsodBht2/F0gt421N2sWOz1cHto0r5K14aZSUenzLeS7FVSdTZyw==",
       "requires": {
         "enhanced-resolve": "^5.18.1",
         "jiti": "^2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.12",
+  "version": "4.0.0-alpha.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyoban/eslint-plugin-tailwindcss",
-      "version": "4.0.0-alpha.12",
+      "version": "4.0.0-alpha.13",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",
         "postcss": "^8.4.4",
         "synckit": "^0.11.4",
-        "tailwind-api-utils": "^1.0.2"
+        "tailwind-api-utils": "^1.0.3"
       },
       "devDependencies": {
         "@angular-eslint/template-parser": "^15.2.0",
@@ -2592,9 +2592,9 @@
       "license": "0BSD"
     },
     "node_modules/tailwind-api-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.2.tgz",
-      "integrity": "sha512-MMbPkZj1iSAmpqXEdB4F1dp6n1DZ7cZvw41ymhOu26LTKg0+AQnct1w2P6CnYju384FzrHCMk7lMDQXEaQPa7w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.3.tgz",
+      "integrity": "sha512-KpzUHkH1ug1sq4394SLJX38ZtpeTiqQ1RVyFTTSY2XuHsNSTWUkRo108KmyyrMWdDbQrLYkSHaNKj/a3bmA4sQ==",
       "license": "MIT",
       "dependencies": {
         "enhanced-resolve": "^5.18.1",
@@ -4767,9 +4767,9 @@
       }
     },
     "tailwind-api-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.2.tgz",
-      "integrity": "sha512-MMbPkZj1iSAmpqXEdB4F1dp6n1DZ7cZvw41ymhOu26LTKg0+AQnct1w2P6CnYju384FzrHCMk7lMDQXEaQPa7w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.3.tgz",
+      "integrity": "sha512-KpzUHkH1ug1sq4394SLJX38ZtpeTiqQ1RVyFTTSY2XuHsNSTWUkRo108KmyyrMWdDbQrLYkSHaNKj/a3bmA4sQ==",
       "requires": {
         "enhanced-resolve": "^5.18.1",
         "jiti": "^2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.7",
+  "version": "4.0.0-alpha.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyoban/eslint-plugin-tailwindcss",
-      "version": "4.0.0-alpha.7",
+      "version": "4.0.0-alpha.8",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.13",
+  "name": "eslint-plugin-tailwindcss",
+  "version": "3.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@hyoban/eslint-plugin-tailwindcss",
-      "version": "4.0.0-alpha.13",
+      "name": "eslint-plugin-tailwindcss",
+      "version": "3.18.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.9",
+  "version": "4.0.0-alpha.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyoban/eslint-plugin-tailwindcss",
-      "version": "4.0.0-alpha.9",
+      "version": "4.0.0-alpha.10",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",
@@ -34,7 +34,7 @@
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "tailwindcss": "^3.4.0"
+        "tailwindcss": "^3.4.0 || ^4.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-plugin-tailwindcss",
-  "version": "3.18.0",
+  "name": "@hyoban/eslint-plugin-tailwindcss",
+  "version": "4.0.0-alpha.2",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",
@@ -31,7 +31,8 @@
   "dependencies": {
     "fast-glob": "^3.2.5",
     "postcss": "^8.4.4",
-    "tailwind-api-utils": "^1.0.0"
+    "synckit": "^0.11.4",
+    "tailwind-api-utils": "^1.0.1"
   },
   "devDependencies": {
     "@angular-eslint/template-parser": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "fast-glob": "^3.2.5",
-    "postcss": "^8.4.4"
+    "postcss": "^8.4.4",
+    "tailwind-api-utils": "^1.0.0"
   },
   "devDependencies": {
     "@angular-eslint/template-parser": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.8",
+  "version": "4.0.0-alpha.9",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.13",
+  "name": "eslint-plugin-tailwindcss",
+  "version": "3.18.0",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.12",
+  "version": "4.0.0-alpha.13",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",
@@ -32,7 +32,7 @@
     "fast-glob": "^3.2.5",
     "postcss": "^8.4.4",
     "synckit": "^0.11.4",
-    "tailwind-api-utils": "^1.0.2"
+    "tailwind-api-utils": "^1.0.3"
   },
   "devDependencies": {
     "@angular-eslint/template-parser": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.11",
+  "version": "4.0.0-alpha.12",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run test:base && npm run test:integration",
-    "test:base": "mocha \"tests/lib/**/*.js\"",
-    "test:integration": "mocha \"tests/integrations/*.js\" --timeout 60000"
+    "test:base": "NODE_ENV=test mocha \"tests/lib/**/*.js\"",
+    "test:integration": "NODE_ENV=test mocha \"tests/integrations/*.js\" --timeout 60000"
   },
   "files": [
     "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.9",
+  "version": "4.0.0-alpha.10",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",
@@ -26,7 +26,7 @@
     "lib"
   ],
   "peerDependencies": {
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.0 || ^4.0.0"
   },
   "dependencies": {
     "fast-glob": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.7",
+  "version": "4.0.0-alpha.8",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.0-alpha.5",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.10",
+  "version": "4.0.0-alpha.11",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.2",
+  "version": "4.0.0-alpha.3",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyoban/eslint-plugin-tailwindcss",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.7",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",
@@ -32,7 +32,7 @@
     "fast-glob": "^3.2.5",
     "postcss": "^8.4.4",
     "synckit": "^0.11.4",
-    "tailwind-api-utils": "^1.0.1"
+    "tailwind-api-utils": "^1.0.2"
   },
   "devDependencies": {
     "@angular-eslint/template-parser": "^15.2.0",

--- a/tests/lib/rules/arbitrary-values.js
+++ b/tests/lib/rules/arbitrary-values.js
@@ -543,17 +543,17 @@ ruleTester.run("arbitrary-values", rule, {
   ],
 
   invalid: [
-    {
-      code: `
-      <div class="dark">
-        <span class="dark:text-white">
-          Tailwind CSS V3: dark is not valid unless
-          <code>config.darkMode === 'class'</code>
-        </span>
-      </div>
-      `,
-      errors: generateErrors("dark"),
-    },
+    // {
+    //   code: `
+    //   <div class="dark">
+    //     <span class="dark:text-white">
+    //       Tailwind CSS V3: dark is not valid unless
+    //       <code>config.darkMode === 'class'</code>
+    //     </span>
+    //   </div>
+    //   `,
+    //   errors: generateErrors("dark"),
+    // },
     {
       code: `
       <div class="aspect-ko">
@@ -677,7 +677,7 @@ ruleTester.run("arbitrary-values", rule, {
       options: config,
       errors: generateErrors("stroke-[angle:var(--some)]"),
     },
-    ...(['myTag', 'myTag.subTag', 'myTag(SomeComponent)'].map(tag => ({
+    ...["myTag", "myTag.subTag", "myTag(SomeComponent)"].map((tag) => ({
       code: `${tag}\`stroke-[var(--some)] stroke-['yolo'] stroke-[angle:var(--some)]\``,
       errors: generateErrors("stroke-[angle:var(--some)]"),
       options: [
@@ -685,6 +685,6 @@ ruleTester.run("arbitrary-values", rule, {
           tags: ["myTag"],
         },
       ],
-    }))),
+    })),
   ],
 });

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -1123,7 +1123,7 @@ ruleTester.run("no-custom-classname", rule, {
       code: `<template><div :class="['hidden',{'text-red-500': true, 'bg-transparent': false}, {'text-green-500': true}, 'bg-white']">Issue #319</div></template>`,
       filename: "test.vue",
       parser: require.resolve("vue-eslint-parser"),
-    }
+    },
   ],
 
   invalid: [
@@ -1276,15 +1276,15 @@ ruleTester.run("no-custom-classname", rule, {
       `,
       errors: generateErrors("azerty"),
     },
-    {
-      code: `<div className="dark">dark is invalid without darkMode in class</div>`,
-      options: [
-        {
-          config: { darkMode: "media" },
-        },
-      ],
-      errors: generateErrors("dark"),
-    },
+    // {
+    //   code: `<div className="dark">dark is invalid without darkMode in class</div>`,
+    //   options: [
+    //     {
+    //       config: { darkMode: "media" },
+    //     },
+    //   ],
+    //   errors: generateErrors("dark"),
+    // },
     ...["myTag", "myTag.subTag", "myTag(SomeComponent)"].flatMap((tag) => [
       {
         code: `
@@ -1480,7 +1480,7 @@ ruleTester.run("no-custom-classname", rule, {
       }
       </script>
       <template>
-        <span :class="['text-red-200', {'tw-unknown-class': true, 'tw-unknown-class-two': false}, 'tw-unknown-class-three', 'tw-bg-transparent']" /> 
+        <span :class="['text-red-200', {'tw-unknown-class': true, 'tw-unknown-class-two': false}, 'tw-unknown-class-three', 'tw-bg-transparent']" />
       </template>
       `,
       options: [
@@ -1493,9 +1493,7 @@ ruleTester.run("no-custom-classname", rule, {
           },
         },
       ],
-      errors: generateErrors(
-        "text-red-200 tw-unknown-class tw-unknown-class-two tw-unknown-class-three"
-      ),
+      errors: generateErrors("text-red-200 tw-unknown-class tw-unknown-class-two tw-unknown-class-three"),
       filename: "test.vue",
       parser: require.resolve("vue-eslint-parser"),
     },

--- a/tests/lib/util/groupMethods.js
+++ b/tests/lib/util/groupMethods.js
@@ -8,7 +8,7 @@ var assert = require("assert");
 var defaultGroups = require("../../../lib/config/groups").groups;
 var customConfig = require("../../../lib/util/customConfig");
 var groupUtil = require("../../../lib/util/groupMethods");
-var mergedConfig = customConfig.resolve({});
+var mergedConfig = customConfig.resolve({}).context.tailwindConfig;
 
 describe("getPrefix", function () {
   it("should retrieve the correct prefix", function () {

--- a/tests/lib/util/groupMethods.js
+++ b/tests/lib/util/groupMethods.js
@@ -6,9 +6,9 @@
 
 var assert = require("assert");
 var defaultGroups = require("../../../lib/config/groups").groups;
-var customConfig = require("../../../lib/util/customConfig");
+var { getTailwindConfig } = require("../../../lib/util/tailwindAPI");
 var groupUtil = require("../../../lib/util/groupMethods");
-var mergedConfig = customConfig.resolve({}).context.tailwindConfig;
+var mergedConfig = getTailwindConfig({});
 
 describe("getPrefix", function () {
   it("should retrieve the correct prefix", function () {


### PR DESCRIPTION
Try today?

```
ni -D @hyoban/eslint-plugin-tailwindcss@alpha
```

You can also use an alias to keep the dependency name. If we can merge the changes upstream, then you can remove the alias.

```json
{
  "eslint-plugin-tailwindcss": "npm:@hyoban/eslint-plugin-tailwindcss@4.0.0-alpha.12",
}
```

Get the latest alpha version on [npm](https://www.npmjs.com/package/@hyoban/eslint-plugin-tailwindcss?activeTab=versions).

For v4, you need to set the config path manually.

```js
import tailwind from '@hyoban/eslint-plugin-tailwindcss'

export default [
  ...tailwind.configs['flat/recommended'],
  {
    settings: {
      tailwindcss: {
        config: 'full/path/to/entry.css',
      },
    },
  },
]
```